### PR TITLE
Inline image name instead of id.

### DIFF
--- a/03-assembla_report_users.rb
+++ b/03-assembla_report_users.rb
@@ -95,9 +95,15 @@ FILES.each do |file|
         @num_unknowns += 1
         h = {}
         h['id'] = user_id
-        h['login'] = "unknown-#{@num_unknowns}"
-        h['name'] = "Unknown ##{@num_unknowns}"
-        h['email'] = "unknown-#{@num_unknowns}@#{JIRA_API_DEFAULT_EMAIL}"
+        if JIRA_API_UNKNOWN_USER_CONSOLIDATE
+            h['login'] = "unknown"
+            h['name'] = "Unknown"
+            h['email'] = "unknown@#{JIRA_API_DEFAULT_EMAIL}"
+        else
+            h['login'] = "unknown-#{@num_unknowns}"
+            h['name'] = "Unknown ##{@num_unknowns}"
+            h['email'] = "unknown-#{@num_unknowns}@#{JIRA_API_DEFAULT_EMAIL}"
+        end
         user_index = create_user_index(h)
       end
       user_index['count'] += 1

--- a/12-jira_import_tickets.rb
+++ b/12-jira_import_tickets.rb
@@ -171,7 +171,7 @@ def create_ticket_jira(ticket, counter, total)
   project_id = @project['id']
   ticket_id = ticket['id']
   ticket_number = ticket['number']
-  summary = reformat_markdown(ticket['summary'], user_ids: @assembla_login_to_jira_id, images: @list_of_images, content_type: 'summary', tickets: @assembla_number_to_jira_key)
+  summary = reformat_markdown(ticket['summary'], user_ids: @assembla_login_to_jira_id, images: @list_of_images, content_type: 'summary', tickets: @assembla_number_to_jira_key).gsub('/\n/',' ')
   created_on = ticket['created_on']
   completed_date = ticket['completed_date']
   due_date = ticket['due_date']

--- a/17-jira_update_status.rb
+++ b/17-jira_update_status.rb
@@ -259,7 +259,7 @@ def jira_update_status(issue_id, assembla_status, counter)
   if result
     # If the issue has been closed (Done) we set the resolution to the appropriate value
     if assembla_status.casecmp('Done').zero? || assembla_status.casecmp('invalid').zero?
-      resolution_name = assembla_status.casecmp('invalid').zero? ? "Won't do" : 'Done'
+      resolution_name = assembla_status.casecmp('invalid').zero? ? "Won't Do" : 'Done'
       resolution_id = @jira_resolution_name_to_id[resolution_name].to_i
       unless resolution_id == '0'
         payload = {

--- a/24-jira_create_sprints.rb
+++ b/24-jira_create_sprints.rb
@@ -209,6 +209,8 @@ goodbye("Cannot find project with name='#{JIRA_API_PROJECT_NAME}'") unless proje
     jira_move_issues_to_sprint(next_sprint, @tickets_sprint_slice)
   end
   @jira_sprints << next_sprint.merge(issues: issues.join(',')).merge(assembla_id: sprint['id'])
+  # Avoid 429 Too Many Requests
+  sleep(5)
 end
 
 # First sprint should be 'active' and the other 'closed'

--- a/lib/common.rb
+++ b/lib/common.rb
@@ -996,8 +996,9 @@ def markdown_image(image, images, content_type)
   if name
     result = "!#{name}#{@content_types_thumbnail[content_type] ? '|thumbnail' : ''}!"
   else
-    result = image
-    warning "Reformat markdown image='#{image}', id='#{id}', text='#{text}' => NOT FOUND"
+    # Assembla API may return [[image:<filename>]] instead of [[image:<id>]] inline in a ticket
+    result = "!#{id}#{@content_types_thumbnail[content_type] ? '|thumbnail' : ''}!"
+    warning "Reformat markdown image='#{image}', id='#{id}', text='#{text}, result='#{result}' => NOT FOUND"
   end
   result
 end

--- a/lib/common.rb
+++ b/lib/common.rb
@@ -52,6 +52,7 @@ JIRA_API_ADMIN_EMAIL = ENV['JIRA_API_ADMIN_EMAIL'].freeze
 JIRA_API_ADMINS_GROUP = (ENV['JIRA_API_ADMINS_GROUP'] || 'jira-administrators').freeze
 JIRA_API_DEFAULT_EMAIL = (ENV['JIRA_API_DEFAULT_EMAIL'] || 'example.org').gsub(/^@/, '').freeze
 JIRA_API_UNKNOWN_USER = (ENV['JIRA_API_UNKNOWN_USER'] || 'unknown.user').freeze
+JIRA_API_UNKNOWN_USER_CONSOLIDATE = ENV['JIRA_API_UNKNOWN_USER_CONSOLIDATE'] == 'true'
 JIRA_API_LEAD_ACCOUNT_ID = ENV['JIRA_API_LEAD_ACCOUNT_ID'].freeze
 
 JIRA_API_IMAGES_THUMBNAIL = (ENV['JIRA_API_IMAGES_THUMBNAIL'] || 'description:false,comments:true').freeze
@@ -1054,6 +1055,11 @@ def rest_client_exception(e, method, url, payload = {})
     message = e.to_s
   end
   puts "#{method} #{url}#{payload.empty? ? '' : ' ' + payload.inspect} => NOK (#{message})"
+  if e.response.include? "429 - Too many requests"
+      puts "429 Too Many Requests: Backoff 5 minutes"
+      puts "Response (#{e.response})"
+      sleep(300)
+  end
   message
 end
 

--- a/lib/common.rb
+++ b/lib/common.rb
@@ -998,7 +998,7 @@ def markdown_image(image, images, content_type)
   else
     # Assembla API may return [[image:<filename>]] instead of [[image:<id>]] inline in a ticket
     result = "!#{id}#{@content_types_thumbnail[content_type] ? '|thumbnail' : ''}!"
-    warning "Reformat markdown image='#{image}', id='#{id}', text='#{text}, result='#{result}' => NOT FOUND"
+    warning "Reformat markdown image='#{image}', id='#{id}', text='#{text}', result='#{result}' => NOT FOUND"
   end
   result
 end


### PR DESCRIPTION
Assembla API may return [[image:_filename_]] instead of [[image:_id_]] inline in a ticket.

Assemble support says it will not be fixed:

> Given your tickets have files from 2015 and 2016. the chances that files were inserted within ticket texts different, are high.
> Another possibility is that someone removed the ID or name and that's what the endpoints are returning.
> Either way, there is nothing we can do with those inconsistencies 😞