### PR TITLE
Sort by Milestone ID

### DIFF
--- a/24-jira_create_sprints.rb
+++ b/24-jira_create_sprints.rb
@@ -32,7 +32,7 @@ puts
 # @sprints = @milestones_assembla.select { |milestone| milestone['title'] =~ /sprint/i }
 
 # Need to sort the sprints so that they appear in the correct order.
-@sprints.sort! { |x, y| y['start_date'].to_s <=> x['start_date'].to_s }
+@sprints.sort! { |x, y| y['id'].to_i <=> x['id'].to_i }
 
 puts "Total sprints: #{@sprints.length}"
 


### PR DESCRIPTION
Gives a more expected sort order, particularly when start_date is not consistently set.